### PR TITLE
Hotfix: Invalid RouteProperties.xml causes app crash (not show any route in list)

### DIFF
--- a/RailworksDownloader/Railworks.cs
+++ b/RailworksDownloader/Railworks.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Xml;
 using static RailworksDownloader.Utils;
 
@@ -133,13 +134,22 @@ namespace RailworksDownloader
             string path = Path.Combine(RWPath, "Content", "Routes");
             List<RouteInfo> list = new List<RouteInfo>();
 
+            var dataList = Directory.GetDirectories(path);
+
             foreach (string dir in Directory.GetDirectories(path))
             {
                 string rp_path = Path.Combine(dir, "RouteProperties.xml");
 
                 if (File.Exists(rp_path))
                 {
-                    list.Add(new RouteInfo(ParseRouteProperties(rp_path).Trim(), Path.GetFileName(dir), dir + Path.DirectorySeparatorChar));
+                    try
+                    {
+                        list.Add(new RouteInfo(ParseRouteProperties(rp_path).Trim(), Path.GetFileName(dir), dir + Path.DirectorySeparatorChar));
+                    }
+                    catch (Exception)
+                    {
+                        MessageBox.Show("Nastala chyba při načítání souboru souboru:" + rp_path, "Chyba", MessageBoxButton.OK, MessageBoxImage.Warning);
+                    }
                 }
                 else
                 {

--- a/RailworksDownloader/Railworks.cs
+++ b/RailworksDownloader/Railworks.cs
@@ -134,8 +134,6 @@ namespace RailworksDownloader
             string path = Path.Combine(RWPath, "Content", "Routes");
             List<RouteInfo> list = new List<RouteInfo>();
 
-            var dataList = Directory.GetDirectories(path);
-
             foreach (string dir in Directory.GetDirectories(path))
             {
                 string rp_path = Path.Combine(dir, "RouteProperties.xml");
@@ -148,7 +146,7 @@ namespace RailworksDownloader
                     }
                     catch (Exception)
                     {
-                        MessageBox.Show("Nastala chyba při načítání souboru souboru:" + rp_path, "Chyba", MessageBoxButton.OK, MessageBoxImage.Warning);
+                        MessageBox.Show("An unexpected error occured during parsing following file.\nUsually it means the file is corrupted:" + rp_path, "Error parsing RouteProperties", MessageBoxButton.OK, MessageBoxImage.Warning);
                     }
                 }
                 else


### PR DESCRIPTION
Hotfix: This fixes/bypasses situation when invalid xml file is read (In my case packed by serz.exe, Altenburg-Wildau route).

When such file is read application crashed, now shows a dialog informing about wrong file.